### PR TITLE
fix: social links opening twice on click

### DIFF
--- a/src/lib/components/SocialLinks/SocialIcon.svelte
+++ b/src/lib/components/SocialLinks/SocialIcon.svelte
@@ -14,14 +14,12 @@
 <Tooltip.Root openDelay={0} closeDelay={200}>
 	<!-- tabindex={-1} -->
 	<Tooltip.Trigger
-		class="transition-transform 
+		class="transition-transform
 			hover:scale-110 hover:-rotate-12
 			focus-within:scale-110 focus-within:-rotate-12
 		"
-		onclick={() => window.open(href)}
 	>
-		<!-- TODO: find out how to us a tag here, had to use onlick above so that focus still opens the tooltip -->
-		<a {href} tabindex={-1}>
+		<a {href} target="_blank" rel="noopener noreferrer" tabindex={-1}>
 			<svg
 				class={[`logo size-16`, title]}
 				aria-hidden="true"


### PR DESCRIPTION
## Summary
- Remove `window.open(href)` onclick handler from `Tooltip.Trigger` in `SocialIcon.svelte`
- The `<a>` tag inside was already navigating, so clicking triggered both: `window.open()` opened a new tab AND the anchor navigated the current tab
- Now the `<a>` tag handles navigation with `target="_blank" rel="noopener noreferrer"`

## Test plan
- [ ] Click each social link (LinkedIn, GitHub, Mastodon, Bluesky) — should open once in a new tab
- [ ] Tooltip still appears on hover/focus

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>