### PR TITLE
feat (about): replace resume PDF preview with Notion link

### DIFF
--- a/src/routes/about/ResumeDialog.svelte
+++ b/src/routes/about/ResumeDialog.svelte
@@ -14,6 +14,20 @@
 	};
 </script>
 
+<a
+	href="https://www.notion.so/luke-floden/Resume-Luke-Floden-2dcceb9403db8008ad19ea812f9de062"
+	target="_blank"
+	rel="noopener noreferrer"
+	class={cn(
+		buttonVariants({ variant: 'outline' }),
+		'text-accent-2 outline outline-accent-2 -outline-offset-1 no-underline'
+	)}
+	onclick={() => trackResumeView('requested')}
+>
+	<p class="gradient-text">Resume!</p>
+</a>
+
+<!-- PDF preview dialog — kept for potential future use
 <Dialog.Root bind:open>
 	<Dialog.Trigger
 		class={cn(
@@ -40,6 +54,7 @@
 		</object>
 	</Dialog.Content>
 </Dialog.Root>
+-->
 
 <style lang="postcss">
 </style>


### PR DESCRIPTION
## Summary
- Replace the in-page PDF preview dialog with a direct link to the Notion resume
- Resume button now opens https://www.notion.so/luke-floden/Resume-Luke-Floden-2dcceb9403db8008ad19ea812f9de062 in a new tab
- PDF preview dialog code is commented out (not removed) for potential future use

## Test plan
- [ ] Click "Resume!" button on about page — opens Notion resume in new tab
- [ ] Button styling unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>